### PR TITLE
Set new patients as pending for activation

### DIFF
--- a/src/components/PatientForm.jsx
+++ b/src/components/PatientForm.jsx
@@ -20,7 +20,7 @@ const PatientForm = () => {
                 // Ya no guardamos el email de la auxiliar aquí
                 treatmentEndDate: new Date(endDate),
                 createdAt: new Date(),
-                status: 'Activo'
+                status: 'Pendiente'
             });
             alert("¡Paciente guardado con éxito!");
             setPatientName('');


### PR DESCRIPTION
## Summary
- default new patient status to "Pendiente" when saving to Firestore
- verified patient list shows an "Activar" option for pending patients

## Testing
- `npm run lint` (fails: no-unused-vars in unrelated components)


------
https://chatgpt.com/codex/tasks/task_e_68977ec7a8a08322a1065a4948d5b3f2