### PR TITLE
Add admin login option

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -43,6 +43,19 @@ export default function Login() {
         >
           Auxiliar
         </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            localStorage.setItem("role", "admin");
+            navigate("/admin");
+          }}
+          disabled={loading}
+          className="btn"
+          style={{ padding: "10px 14px", cursor: "pointer" }}
+        >
+          Admin
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add admin button to login view to set admin role and navigate to admin route

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5c2f792c8322b23380f1496bd99b