### PR TITLE
feat: update medico view for new patient schema

### DIFF
--- a/src/components/MedicoView.jsx
+++ b/src/components/MedicoView.jsx
@@ -106,9 +106,13 @@ export default function MedicoView() {
             {activos.map((p) => (
               <li key={p.id} style={{ marginBottom: 6 }}>
                 <b>
-                  {(p.nombreCompleto || `${p.firstName || ""} ${p.lastName || ""}`).trim()}
+                  {(
+                    p.nombreCompleto ||
+                    `${p.firstName || ""} ${p.lastName || ""}`.trim() ||
+                    "—"
+                  )}
                 </b>
-                {" "}— Cédula: {p.cedula || "-"} — Ingreso: {formatDate(p.fechaIngreso)}
+                {" "}— Cédula: {p.cedula || "—"} — Ingreso: {formatDate(p.fechaIngreso)}
                 <button
                   onClick={() => nav(`/paciente/${p.id}`)}
                   style={{ marginLeft: 8 }}
@@ -136,9 +140,13 @@ export default function MedicoView() {
             {finalizados.map((p) => (
               <li key={p.id} style={{ marginBottom: 6 }}>
                 <b>
-                  {(p.nombreCompleto || `${p.firstName || ""} ${p.lastName || ""}`).trim()}
+                  {(
+                    p.nombreCompleto ||
+                    `${p.firstName || ""} ${p.lastName || ""}`.trim() ||
+                    "—"
+                  )}
                 </b>
-                {" "}— Cédula: {p.cedula || "-"} — Fin: {formatDate(p.fechaFin)}
+                {" "}— Cédula: {p.cedula || "—"} — Fin: {formatDate(p.fechaFin)}
                 <button
                   onClick={() => nav(`/paciente/${p.id}`)}
                   style={{ marginLeft: 8 }}


### PR DESCRIPTION
## Summary
- subscribe to `patients` collection and split active and finalized lists
- display patient name and ID with fallbacks and format dates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a8d3565788322b562c1d749e27702