### PR TITLE
fix: actualizar PatientDetail para datos de pacientes

### DIFF
--- a/src/components/PatientDetail.jsx
+++ b/src/components/PatientDetail.jsx
@@ -1,12 +1,12 @@
 // src/components/PatientDetail.jsx
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { db } from "../firebaseConfig";
 import {
   collection,
   doc,
-  getDoc,
   getDocs,
+  onSnapshot,
   orderBy,
   query,
   where,
@@ -17,52 +17,55 @@ import VitalCharts from "./VitalCharts";
 export default function PatientDetail() {
   const { id } = useParams(); // idDoc del paciente (ahora suele ser la cédula)
   const nav = useNavigate();
-  const [patient, setPatient] = useState(null);
+  const [patient, setPatient] = useState(undefined);
   const [vitals, setVitals] = useState([]);
   const [candidatos, setCandidatos] = useState([]); // posibles docs viejos para importar
 
-  // carga el paciente + vitals
+  // escucha al paciente y carga vitals
   useEffect(() => {
-    (async () => {
-      // paciente
-      const ref = doc(db, "patients", id);
-      const snap = await getDoc(ref);
+    const ref = doc(db, "patients", id);
+    const unsubscribe = onSnapshot(ref, snap => {
       if (snap.exists()) {
         const data = { idDoc: snap.id, ...snap.data() };
         setPatient(data);
       } else {
         setPatient(null);
+        setVitals([]);
+        setCandidatos([]);
       }
+    });
+    return () => unsubscribe();
+  }, [id]);
 
-      // vitals en el doc actual
+  // carga vitals y busca candidatos cuando cambia el paciente
+  useEffect(() => {
+    if (!id || patient === null) return;
+    (async () => {
       const vSnap = await getDocs(
         query(collection(db, `patients/${id}/vitals`), orderBy("timestamp", "desc"))
       );
       const v = vSnap.docs.map(d => ({ id: d.id, ...d.data() }));
       setVitals(v);
 
-      // si no hay vitals, buscar otros docs con mismo "id" (la cédula)
-      if ((v?.length ?? 0) === 0 && snap.exists()) {
-        const cedula = snap.data()?.id;
+      // si no hay vitals, buscar otros docs con misma cédula
+      if ((v?.length ?? 0) === 0 && patient) {
+        const cedula = patient.cedula;
         if (cedula) {
           const dupSnap = await getDocs(
-            query(collection(db, "patients"), where("id", "==", cedula))
+            query(collection(db, "patients"), where("cedula", "==", cedula))
           );
           const otros = dupSnap.docs
             .map(d => ({ idDoc: d.id, ...d.data() }))
             .filter(d => d.idDoc !== id);
           setCandidatos(otros);
+        } else {
+          setCandidatos([]);
         }
       } else {
         setCandidatos([]);
       }
     })();
-  }, [id]);
-
-  const titulo = useMemo(() => {
-    if (!patient) return "Paciente";
-    return `${patient.name || "Paciente"} — ${patient.id || ""}`;
-  }, [patient]);
+  }, [id, patient]);
 
   const importarDesde = async (legacyIdDoc) => {
     // copia subcolección vitals desde legacyIdDoc -> id (doc actual)
@@ -89,49 +92,65 @@ export default function PatientDetail() {
     }
   };
 
+  if (patient === undefined) {
+    return (
+      <div style={{ maxWidth: 1000, margin: "0 auto", padding: 16 }}>
+        <button onClick={() => nav(-1)} style={{ marginBottom: 12 }}>← Volver</button>
+        <h1>Detalle del paciente</h1>
+        <p>Cargando...</p>
+      </div>
+    );
+  }
+
+  if (patient === null) {
+    return (
+      <div style={{ maxWidth: 1000, margin: "0 auto", padding: 16 }}>
+        <button onClick={() => nav(-1)} style={{ marginBottom: 12 }}>← Volver</button>
+        <h1>Detalle del paciente</h1>
+        <p>Paciente no encontrado.</p>
+      </div>
+    );
+  }
+
   return (
     <div style={{ maxWidth: 1000, margin: "0 auto", padding: 16 }}>
       <button onClick={() => nav(-1)} style={{ marginBottom: 12 }}>← Volver</button>
       <h1>Detalle del paciente</h1>
-      {patient ? (
-        <>
-          <div style={{ marginBottom: 8 }}>
-            <b>Nombre:</b> {patient.name || "—"}
-          </div>
-          <div style={{ marginBottom: 8 }}>
-            <b>Cédula:</b> {patient.id || "—"}
-          </div>
-          <div style={{ marginBottom: 16 }}>
-            <b>Estado:</b> {patient.status || "—"}
-          </div>
+      <>
+        <div style={{ marginBottom: 8 }}>
+          <b>Nombre:</b> {patient.nombreCompleto || `${patient.firstName || ""} ${patient.lastName || ""}`.trim() || "—"}
+        </div>
+        <div style={{ marginBottom: 8 }}>
+          <b>Cédula:</b> {patient.cedula || "—"}
+        </div>
+        <div style={{ marginBottom: 16 }}>
+          <b>Estado:</b> {patient.status || "—"}
+        </div>
 
-          {/* Si no hay vitals, ofrece importar desde docs viejos con misma cédula */}
-          {vitals.length === 0 && candidatos.length > 0 && (
-            <div style={{ background:"#fff4e5", padding:12, borderRadius:8, marginBottom:16 }}>
-              <b>No hay signos en este documento.</b> Encontré historiales en:
-              <ul>
-                {candidatos.map(c => (
-                  <li key={c.idDoc} style={{ marginTop:6 }}>
-                    Doc antiguo: <code>{c.idDoc}</code>{" "}
-                    <button onClick={() => importarDesde(c.idDoc)} style={{ marginLeft:8 }}>
-                      Importar signos
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+        {/* Si no hay vitals, ofrece importar desde docs viejos con misma cédula */}
+        {vitals.length === 0 && candidatos.length > 0 && (
+          <div style={{ background:"#fff4e5", padding:12, borderRadius:8, marginBottom:16 }}>
+            <b>No hay signos en este documento.</b> Encontré historiales en:
+            <ul>
+              {candidatos.map(c => (
+                <li key={c.idDoc} style={{ marginTop:6 }}>
+                  Doc antiguo: <code>{c.idDoc}</code>{" "}
+                  <button onClick={() => importarDesde(c.idDoc)} style={{ marginLeft:8 }}>
+                    Importar signos
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
-          {/* Gráficas si existen */}
-          {vitals.length > 0 ? (
-            <VitalCharts vitals={vitals} />
-          ) : (
-            <p>Sin registros de signos todavía.</p>
-          )}
-        </>
-      ) : (
-        <p>No se encontró el paciente.</p>
-      )}
+        {/* Gráficas si existen */}
+        {vitals.length > 0 ? (
+          <VitalCharts vitals={vitals} />
+        ) : (
+          <p>Sin registros de signos todavía.</p>
+        )}
+      </>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- suscribe PatientDetail al documento de pacientes con `onSnapshot`
- muestra nombre, cédula y estado usando los nuevos campos
- maneja paciente inexistente y limpia listeners

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a8fe188e883228432313c5daa8612