### PR TITLE
Normalize blood pressure input and store numeric components

### DIFF
--- a/src/components/PatientHistoryModal.jsx
+++ b/src/components/PatientHistoryModal.jsx
@@ -79,11 +79,11 @@ export default function PatientHistoryModal({ patientId, onClose }) {
                 <tr key={r.id}>
                   <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{formatDate(r.createdAt)}</td>
                   <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.temp ?? "-"}</td>
-                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.hr ?? "-"}</td>
-                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.rr ?? "-"}</td>
-                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.bp ?? "-"}</td>
+                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.hr ?? r.fc ?? "-"}</td>
+                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.rr ?? r.fr ?? "-"}</td>
+                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.bp ?? r.ta ?? "-"}</td>
                   <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.spo2 ?? "-"}</td>
-                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.notes || "-"}</td>
+                  <td style={{ borderBottom: "1px solid #eee", padding: "4px 8px" }}>{r.notes || r.nota || "-"}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/utils/bp.js
+++ b/src/utils/bp.js
@@ -1,0 +1,17 @@
+export function parseBP(value) {
+  if (value == null) return null;
+  const str = String(value).trim();
+  const match = str.match(/(\d{2,3})\D*(\d{2,3})/);
+  if (match) {
+    const sys = Number(match[1]);
+    const dia = Number(match[2]);
+    return { sys, dia, text: `${sys}/${dia}` };
+  }
+  const digits = str.replace(/\D/g, "");
+  if (digits.length >= 4 && digits.length <= 6) {
+    const sys = Number(digits.slice(0, -2));
+    const dia = Number(digits.slice(-2));
+    return { sys, dia, text: `${sys}/${dia}` };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- normalize blood pressure input with parseBP and validate before saving
- store bp text plus numeric systolic/diastolic fields alongside existing vitals
- update charts and history to read new fields and parse legacy data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'vite/.../dep-C6uTJdX2.js')*

------
https://chatgpt.com/codex/tasks/task_e_689a9825cbb083228825aa2f70f3bb28