### PR TITLE
fix: install recharts and update imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "recharts": "^2.10.4"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.2",

--- a/src/components/VitalCharts.jsx
+++ b/src/components/VitalCharts.jsx
@@ -1,14 +1,11 @@
 // src/components/VitalCharts.jsx
 import { useMemo } from "react";
 import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
   ResponsiveContainer,
+  LineChart, Line,
+  XAxis, YAxis,
+  CartesianGrid,
+  Tooltip, Legend
 } from "recharts";
 import { parseBP } from "../utils/bp";
 


### PR DESCRIPTION
## Summary
- add Recharts to dependencies
- adjust VitalCharts to use named imports from recharts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Cannot find module '/workspace/mi-app-medica/node_modules/vite/dist/node/chunks/dep-C6uTJdX2.js' imported from /workspace/mi-app-medica/node_modules/vite/dist/node/cli.js)


------
https://chatgpt.com/codex/tasks/task_e_689aac6917508322ae9ea5fda4f51381