### PR TITLE
Show planned and real treatment end dates

### DIFF
--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -28,6 +28,13 @@ function fmt(v) {
   return `${dd}/${mm}/${yyyy}`;
 }
 
+function finDisplay(p) {
+  return fmt(p.finAt ?? p.finEstimadoAt ?? p.fin);
+}
+function ingresoDisplay(p) {
+  return fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
+}
+
 function formatName(p) {
   const name = (p.nombreCompleto || `${p.firstName || ""} ${p.lastName || ""}`).trim();
   return name || "—";
@@ -88,14 +95,18 @@ export default function AdminView() {
   };
   const renderRows = (list, tipo) =>
     list.map((p) => {
-      const ingreso = fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
-      const fin = fmt(p.finAt ?? p.fin);
+      const ingreso = ingresoDisplay(p);
+      const fin = finDisplay(p);
+      const isEstimado = !!p.finEstimadoAt && !p.finAt;
       return (
         <tr key={p.id}>
           <td>{formatName(p)}</td>
           <td>{p.cedula || "—"}</td>
           <td>{ingreso}</td>
-          <td>{fin}</td>
+          <td>
+            {fin}
+            {isEstimado ? " (planificado)" : ""}
+          </td>
           <td>
             <div style={{ display: "flex", gap: 8 }}>
               <button

--- a/src/components/AuxiliarView.jsx
+++ b/src/components/AuxiliarView.jsx
@@ -16,6 +16,28 @@ import VitalCharts from "./VitalCharts";
 import LogoutButton from "./LogoutButton";
 import { parseBP } from "../utils/bp";
 
+function asDate(v) {
+  if (!v) return null;
+  if (v.seconds) return new Date(v.seconds * 1000);
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  return isNaN(d) ? null : d;
+}
+function fmt(v) {
+  const d = asDate(v);
+  if (!d) return "—";
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = d.getFullYear();
+  return `${dd}/${mm}/${yyyy}`;
+}
+function finDisplay(p) {
+  return fmt(p.finAt ?? p.finEstimadoAt ?? p.fin);
+}
+function ingresoDisplay(p) {
+  return fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
+}
+
 export default function AuxiliarView() {
 
   const [cedulaBuscar, setCedulaBuscar] = useState("");
@@ -232,6 +254,9 @@ export default function AuxiliarView() {
                     </p>
                     <p>
                       <b>Estado:</b> {paciente.status || paciente.estado || "-"}
+                    </p>
+                    <p>
+                      <b>Fin:</b> {finDisplay(paciente)}
                     </p>
 
                     <h2>Nuevo registro de signos</h2>

--- a/src/components/MedicoView.jsx
+++ b/src/components/MedicoView.jsx
@@ -68,6 +68,13 @@ export default function MedicoView() {
     return `${dd}/${mm}/${yyyy}`;
   }
 
+  function finDisplay(p) {
+    return fmt(p.finAt ?? p.finEstimadoAt ?? p.fin);
+  }
+  function ingresoDisplay(p) {
+    return fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
+  }
+
   const finalizar = async (p) => {
     try {
       const ts = serverTimestamp();
@@ -112,8 +119,8 @@ export default function MedicoView() {
           ) : (
             <ul>
               {activos.map((p) => {
-                const ingreso = fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
-                const fin = fmt(p.finAt ?? p.fin);
+                const ingreso = ingresoDisplay(p);
+                const fin = finDisplay(p);
                 return (
                   <li key={p.id} className="card">
                     <div className="card-body">
@@ -156,8 +163,8 @@ export default function MedicoView() {
           ) : (
             <ul>
               {finalizados.map((p) => {
-                const ingreso = fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
-                const fin = fmt(p.finAt ?? p.fin);
+                const ingreso = ingresoDisplay(p);
+                const fin = finDisplay(p);
                 return (
                   <li key={p.id} className="card">
                     <div className="card-body">

--- a/src/components/PatientForm.jsx
+++ b/src/components/PatientForm.jsx
@@ -14,7 +14,7 @@ export default function PatientForm({ onClose, onCreated }) {
   const [form, setForm] = useState({
     nombreCompleto: "",
     cedula: "",
-    fechaFin: "",
+    finEstimado: "",
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
@@ -30,7 +30,7 @@ export default function PatientForm({ onClose, onCreated }) {
     if (
       !form.nombreCompleto.trim() ||
       !form.cedula.trim() ||
-      !form.fechaFin
+      !form.finEstimado
     ) {
       setError(
         "Nombre completo, cédula y fecha de finalización son obligatorios"
@@ -49,13 +49,19 @@ export default function PatientForm({ onClose, onCreated }) {
         setSaving(false);
         return;
       }
+      const finEstimadoDate = form.finEstimado
+        ? new Date(`${form.finEstimado}T00:00:00`)
+        : null;
       await addDoc(collection(db, "patients"), {
         nombreCompleto: form.nombreCompleto.trim(),
         cedula: String(form.cedula).trim(),
         status: "pendiente",
         fechaIngreso: serverTimestamp(),
         ingresoAt: serverTimestamp(),
-        fechaFin: Timestamp.fromDate(new Date(form.fechaFin)),
+        fechaFin: finEstimadoDate
+          ? Timestamp.fromDate(finEstimadoDate)
+          : null,
+        finEstimadoAt: finEstimadoDate,
         finAt: null,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
@@ -117,8 +123,8 @@ export default function PatientForm({ onClose, onCreated }) {
           Fecha de finalización
           <input
             type="date"
-            name="fechaFin"
-            value={form.fechaFin}
+            name="finEstimado"
+            value={form.finEstimado}
             onChange={change}
             required
             style={{ display: "block", width: "100%", marginTop: 4, padding: 8 }}


### PR DESCRIPTION
## Summary
- capture estimated treatment completion when creating patients and store finEstimadoAt for later comparison
- surface planned vs actual finish dates across admin, medical, and auxiliary views with unified date helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bb12882d883229a7ba87cb27b23f2