### PR TITLE
feat: support legacy date formats

### DIFF
--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -11,29 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { db } from "../firebaseConfig";
 import PatientForm from "./PatientForm";
 import LogoutButton from "./LogoutButton";
-
-function asDate(v) {
-  if (!v) return null;
-  if (v.seconds) return new Date(v.seconds * 1000);
-  if (v instanceof Date) return v;
-  const d = new Date(v);
-  return isNaN(d) ? null : d;
-}
-function fmt(v) {
-  const d = asDate(v);
-  if (!d) return "—";
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = d.getFullYear();
-  return `${dd}/${mm}/${yyyy}`;
-}
-
-function finDisplay(p) {
-  return fmt(p.finAt ?? p.finEstimadoAt ?? p.fin);
-}
-function ingresoDisplay(p) {
-  return fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
-}
+import { ingresoDisplay, finDisplay } from "../utils/dates";
 
 function formatName(p) {
   const name = (p.nombreCompleto || `${p.firstName || ""} ${p.lastName || ""}`).trim();

--- a/src/components/AuxiliarView.jsx
+++ b/src/components/AuxiliarView.jsx
@@ -15,28 +15,7 @@ import { db } from "../firebaseConfig";
 import VitalCharts from "./VitalCharts";
 import LogoutButton from "./LogoutButton";
 import { parseBP } from "../utils/bp";
-
-function asDate(v) {
-  if (!v) return null;
-  if (v.seconds) return new Date(v.seconds * 1000);
-  if (v instanceof Date) return v;
-  const d = new Date(v);
-  return isNaN(d) ? null : d;
-}
-function fmt(v) {
-  const d = asDate(v);
-  if (!d) return "—";
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = d.getFullYear();
-  return `${dd}/${mm}/${yyyy}`;
-}
-function finDisplay(p) {
-  return fmt(p.finAt ?? p.finEstimadoAt ?? p.fin);
-}
-function ingresoDisplay(p) {
-  return fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
-}
+import { finDisplay } from "../utils/dates";
 
 export default function AuxiliarView() {
 

--- a/src/components/MedicoView.jsx
+++ b/src/components/MedicoView.jsx
@@ -10,6 +10,7 @@ import {
   serverTimestamp,
 } from "firebase/firestore";
 import LogoutButton from "./LogoutButton";
+import { asDate, ingresoDisplay, finDisplay } from "../utils/dates";
 
 export default function MedicoView() {
   const nav = useNavigate();
@@ -52,28 +53,6 @@ export default function MedicoView() {
     return () => unsub();
   }, []);
 
-  function asDate(v) {
-    if (!v) return null;
-    if (v.seconds) return new Date(v.seconds * 1000);
-    if (v instanceof Date) return v;
-    const d = new Date(v);
-    return isNaN(d) ? null : d;
-  }
-  function fmt(v) {
-    const d = asDate(v);
-    if (!d) return "—";
-    const dd = String(d.getDate()).padStart(2, "0");
-    const mm = String(d.getMonth() + 1).padStart(2, "0");
-    const yyyy = d.getFullYear();
-    return `${dd}/${mm}/${yyyy}`;
-  }
-
-  function finDisplay(p) {
-    return fmt(p.finAt ?? p.finEstimadoAt ?? p.fin);
-  }
-  function ingresoDisplay(p) {
-    return fmt(p.ingresoAt ?? p.ingreso ?? p.createdAt);
-  }
 
   const finalizar = async (p) => {
     try {

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,0 +1,60 @@
+export function parseLegacyDate(value) {
+  if (!value) return null;
+  // Firestore Timestamp
+  if (value && typeof value === "object" && "seconds" in value) {
+    return new Date(value.seconds * 1000);
+  }
+  if (value instanceof Date) return value;
+
+  if (typeof value === "string") {
+    const s = value.trim();
+    // dd/mm/yyyy | dd-mm-yyyy | dd.mm.yyyy
+    let m = s.match(/^(\d{1,2})[\/\-.](\d{1,2})[\/\-.](\d{2,4})$/);
+    if (m) {
+      let [, d, mm, y] = m;
+      if (y.length === 2) y = "20" + y;
+      const dt = new Date(+y, +mm - 1, +d);
+      return isNaN(+dt) ? null : dt;
+    }
+    // yyyy-mm-dd | yyyy/mm/dd | yyyy.mm.dd
+    m = s.match(/^(\d{4})[\/\-.](\d{1,2})[\/\-.](\d{1,2})$/);
+    if (m) {
+      const [, y, mm, d] = m;
+      const dt = new Date(+y, +mm - 1, +d);
+      return isNaN(+dt) ? null : dt;
+    }
+    // Último intento: Date nativo
+    const dt = new Date(s);
+    if (!isNaN(+dt)) return dt;
+  }
+  return null;
+}
+
+export function asDate(v) {
+  return parseLegacyDate(v);
+}
+
+export function fmtDate(v) {
+  const d = asDate(v);
+  if (!d) return "—";
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = d.getFullYear();
+  return `${dd}/${mm}/${yyyy}`;
+}
+
+export function ingresoDisplay(p) {
+  // ingresoAt (TS) | ingreso (string) | createdAt (TS)
+  return fmtDate(p.ingresoAt ?? p.ingreso ?? p.createdAt);
+}
+
+export function finDisplay(p) {
+  // Prioridad: real > estimado > legacy strings/campos alternos
+  const v =
+    p.finAt ??
+    p.finEstimadoAt ??
+    p.fin ?? // legacy string
+    p.fechaFin ?? // otros nombres posibles
+    p.finDate; // otros nombres posibles
+  return fmtDate(v);
+}


### PR DESCRIPTION
## Summary
- add shared helpers to parse legacy date strings and format dates
- display patient ingreso/fin using new helpers across Admin, Médico and Auxiliar views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'vite/dist/node/chunks/dep-C6uTJdX2.js')*

------
https://chatgpt.com/codex/tasks/task_e_689bb6122f3483228dc5fa12391c7dc4