### PR TITLE
feat: add public user registration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 
 import LoginByCedula from "./components/LoginByCedula.jsx";
-import Register from "./components/Register.jsx";
+import UserRegister from "./components/UserRegister.jsx";
 import MedicoView from "./components/MedicoView.jsx";
 import AuxiliarView from "./components/AuxiliarView.jsx";
 import AdminView from "./components/AdminView.jsx";
@@ -35,7 +35,7 @@ export default function App() {
       <Routes>
         {/* públicas */}
         <Route path="/" element={<LoginByCedula />} />
-        <Route path="/registro" element={<Register />} />
+        <Route path="/registro" element={<UserRegister />} />
 
         {/* dejamos rutas SIEMPRE disponibles (más simple p/ superadmin) */}
         <Route path="/medico" element={<MedicoView />} />

--- a/src/components/UserRegister.jsx
+++ b/src/components/UserRegister.jsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { createUser } from "../lib/users";
+
+export default function UserRegister() {
+  const [params] = useSearchParams();
+  const cedulaFromQuery = params.get("cedula") || "";
+  const [form, setForm] = useState({
+    nombreCompleto: "",
+    cedula: cedulaFromQuery,
+    correo: "",
+  });
+  const [saving, setSaving] = useState(false);
+  const navigate = useNavigate();
+
+  const onChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const { nombreCompleto, cedula, correo } = form;
+    if (!nombreCompleto.trim() || !cedula.trim() || !correo.trim()) return;
+    if (!correo.includes("@")) return;
+    setSaving(true);
+    try {
+      await createUser({
+        cedula: cedula.trim(),
+        nombreCompleto: nombreCompleto.trim(),
+        correo: correo.trim(),
+        role: "auxiliar",
+      });
+      localStorage.setItem("role", "auxiliar");
+      localStorage.setItem("userId", cedula.trim());
+      localStorage.setItem("userName", nombreCompleto.trim());
+      navigate("/auxiliar");
+    } catch (err) {
+      console.error("Error registrando usuario:", err);
+      alert("No se pudo registrar. Revisa la consola.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} style={{ maxWidth: 420, margin: "40px auto", padding: 16 }}>
+      <h1 style={{ marginBottom: 20 }}>Registro de Auxiliar</h1>
+      <input
+        className="input"
+        name="nombreCompleto"
+        placeholder="Nombre y apellido"
+        value={form.nombreCompleto}
+        onChange={onChange}
+        style={{ marginBottom: 12 }}
+      />
+      <input
+        className="input"
+        name="cedula"
+        placeholder="Cédula"
+        value={form.cedula}
+        onChange={onChange}
+        readOnly={Boolean(cedulaFromQuery)}
+        style={{ marginBottom: 12 }}
+      />
+      <input
+        className="input"
+        name="correo"
+        type="email"
+        placeholder="Correo"
+        value={form.correo}
+        onChange={onChange}
+        style={{ marginBottom: 12 }}
+      />
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => navigate("/")}
+          style={{ flex: 1 }}
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          className="btn primary"
+          style={{ flex: 1 }}
+        >
+          {saving ? "Guardando..." : "Registrar"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -1,5 +1,5 @@
 import { db, ensureAuth } from "../firebaseConfig";
-import { doc, getDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore";
 
 export async function getUserByCedula(cedula) {
   await ensureAuth();
@@ -13,4 +13,18 @@ export async function getUserByCedula(cedula) {
     correo: data.correo || "",
     role: data.role || data.rol || "",
   };
+}
+
+export async function createUser({ cedula, nombreCompleto, correo, role }) {
+  await ensureAuth();
+  const id = String(cedula).trim();
+  const ref = doc(db, "users", id);
+  await setDoc(ref, {
+    cedula: id,
+    nombreCompleto,
+    correo,
+    role,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
 }


### PR DESCRIPTION
## Summary
- add createUser util for Firestore user creation
- create UserRegister component for public auxiliar signup
- wire up /registro route to new registration screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '.../vite/dist/node/chunks/dep-C6uTJdX2.js')*

------
https://chatgpt.com/codex/tasks/task_e_689bd043e8f48322b7b8859dbf80c93c