### PR TITLE
feat: admin user management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import AdminView from "./components/AdminView.jsx";
 import PatientDetail from "./components/PatientDetail.jsx";
 import SuperNav from "./components/SuperNav.jsx";
 import RoleRoute from "./components/RoleRoute.jsx";
+import ProtectedRoute from "./components/ProtectedRoute.jsx";
+import UsersAdmin from "./components/UsersAdmin.jsx";
 
 export default function App() {
   // Lee el rol desde localStorage pero en estado, para que re-renderice
@@ -62,6 +64,14 @@ export default function App() {
             <RoleRoute allow={["admin", "superadmin"]}>
               <AdminView />
             </RoleRoute>
+          }
+        />
+        <Route
+          path="/usuarios"
+          element={
+            <ProtectedRoute role="admin">
+              <UsersAdmin />
+            </ProtectedRoute>
           }
         />
 

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -166,7 +166,12 @@ export default function AdminView() {
       <div className="container">
         <div className="section-header">
           <h1 className="section-title">Pacientes</h1>
-          <LogoutButton />
+          <div style={{ display: "flex", gap: 8 }}>
+            {isAdmin() && (
+              <button className="btn" onClick={() => navigate("/usuarios")}>Usuarios</button>
+            )}
+            <LogoutButton />
+          </div>
         </div>
 
         <button className="btn primary" onClick={() => setCreating(true)}>

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,6 +1,8 @@
 import { Navigate } from "react-router-dom";
 
-export default function ProtectedRoute({ children }) {
-  const role = localStorage.getItem("role");
-  return role ? children : <Navigate to="/" replace />;
+export default function ProtectedRoute({ children, role }) {
+  const current = localStorage.getItem("role");
+  if (!current) return <Navigate to="/" replace />;
+  if (role && current !== role) return <Navigate to="/" replace />;
+  return children;
 }

--- a/src/components/UsersAdmin.jsx
+++ b/src/components/UsersAdmin.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  getUsersPage,
+  findUserByCedula,
+  updateUserRole,
+} from "../lib/users";
+
+export default function UsersAdmin() {
+  const [users, setUsers] = useState([]);
+  const [cedula, setCedula] = useState("");
+  const [roles, setRoles] = useState({});
+  const navigate = useNavigate();
+  const myCedula = localStorage.getItem("userId");
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const rows = await getUsersPage();
+        setUsers(rows);
+      } catch (err) {
+        console.error(err);
+        alert("No se pudieron cargar los usuarios. Revisa la consola.");
+      }
+    })();
+  }, []);
+
+  const buscar = async () => {
+    try {
+      if (cedula.trim()) {
+        const u = await findUserByCedula(cedula.trim());
+        if (u) {
+          setUsers([{ ...u, cedula: u.cedula || u.id }]);
+        } else {
+          setUsers([]);
+          alert("Usuario no encontrado.");
+        }
+      } else {
+        const rows = await getUsersPage();
+        setUsers(rows);
+      }
+    } catch (err) {
+      console.error(err);
+      alert("No se pudo buscar. Revisa la consola.");
+    }
+  };
+
+  const onChangeRole = (id, role) => {
+    setRoles((prev) => ({ ...prev, [id]: role }));
+  };
+
+  const guardar = async (u) => {
+    const newRole = roles[u.id] || u.role || "";
+    try {
+      await updateUserRole(u.id, newRole);
+      alert("Rol actualizado");
+      const updatedAt = new Date();
+      setUsers((prev) =>
+        prev.map((p) =>
+          p.id === u.id ? { ...p, role: newRole, updatedAt } : p
+        )
+      );
+      if (u.id === myCedula) {
+        localStorage.setItem("role", newRole);
+        if (newRole !== "admin") {
+          const route =
+            newRole === "medico" ? "/medico" : newRole === "auxiliar" ? "/auxiliar" : "/";
+          navigate(route);
+        }
+      }
+    } catch (err) {
+      console.error(err);
+      alert("No se pudo actualizar. Revisa la consola.");
+    }
+  };
+
+  const formatDate = (ts) => {
+    if (!ts) return "—";
+    const d = ts.toDate ? ts.toDate() : new Date(ts);
+    return d.toLocaleString();
+    };
+
+  return (
+    <div className="page">
+      <div className="container">
+        <div className="section-header" style={{ gap: 8 }}>
+          <h1 className="section-title">Usuarios</h1>
+          <div style={{ display: "flex", gap: 8 }}>
+            <input
+              placeholder="Cédula"
+              value={cedula}
+              onChange={(e) => setCedula(e.target.value)}
+            />
+            <button className="btn" onClick={buscar}>
+              Buscar
+            </button>
+          </div>
+        </div>
+
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Nombre</th>
+                <th>Cédula</th>
+                <th>Correo</th>
+                <th>Rol actual</th>
+                <th>Actualizado</th>
+                <th>Acción</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.length === 0 ? (
+                <tr>
+                  <td colSpan={6}>No hay usuarios</td>
+                </tr>
+              ) : (
+                users.map((u) => (
+                  <tr key={u.id}>
+                    <td>{u.nombreCompleto || "—"}</td>
+                    <td>{u.cedula || u.id}</td>
+                    <td>{u.correo || "—"}</td>
+                    <td>
+                      <select
+                        value={roles[u.id] || u.role || ""}
+                        onChange={(e) => onChangeRole(u.id, e.target.value)}
+                      >
+                        <option value="auxiliar">auxiliar</option>
+                        <option value="medico">medico</option>
+                        <option value="admin">admin</option>
+                      </select>
+                    </td>
+                    <td>{formatDate(u.updatedAt)}</td>
+                    <td>
+                      <button className="btn" onClick={() => guardar(u)}>
+                        Guardar
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -1,5 +1,16 @@
 import { db, ensureAuth } from "../firebaseConfig";
-import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  setDoc,
+  updateDoc,
+  getDocs,
+  collection,
+  query,
+  orderBy,
+  limit,
+  serverTimestamp,
+} from "firebase/firestore";
 
 export async function getUserByCedula(cedula) {
   await ensureAuth();
@@ -27,4 +38,32 @@ export async function createUser({ cedula, nombreCompleto, correo, role }) {
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   });
+}
+
+export async function updateUserRole(cedula, role) {
+  await ensureAuth();
+  const ref = doc(db, "users", String(cedula));
+  await updateDoc(ref, {
+    role,
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export async function getUsersPage(limitN = 50) {
+  await ensureAuth();
+  const q = query(
+    collection(db, "users"),
+    orderBy("createdAt", "desc"),
+    limit(limitN)
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+export async function findUserByCedula(cedula) {
+  await ensureAuth();
+  const ref = doc(db, "users", String(cedula));
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  return { id: snap.id, ...snap.data() };
 }


### PR DESCRIPTION
## Summary
- add Firestore helpers for updating and fetching users
- implement admin Users screen to search and update roles
- wire new /usuarios route and navigation link for admins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '.../node_modules/vite/dist/node/chunks/dep-C6uTJdX2.js')*

------
https://chatgpt.com/codex/tasks/task_e_689bdbddcd10832296c737a447f68ca2