### PR TITLE
Normalize cedula and prevent duplicate registrations

### DIFF
--- a/src/components/LoginByCedula.jsx
+++ b/src/components/LoginByCedula.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getUserByCedula } from "../lib/users";
 
+const normCed = (s) => (s || "").toString().trim().replace(/[.\s-]/g, "");
+
 export default function LoginByCedula() {
   const [cedula, setCedula] = useState("");
   const [buscando, setBuscando] = useState(false);
@@ -9,11 +11,11 @@ export default function LoginByCedula() {
 
   const submit = async (e) => {
     e.preventDefault();
-    const valor = cedula.trim();
-    if (!valor) return;
+    const ced = normCed(cedula);
+    if (!ced) return;
     setBuscando(true);
     try {
-      const user = await getUserByCedula(valor);
+      const user = await getUserByCedula(ced);
       if (user) {
         localStorage.setItem("role", user.role || "");
         localStorage.setItem("userId", user.cedula);
@@ -23,7 +25,7 @@ export default function LoginByCedula() {
         else if (user.role === "auxiliar") nav("/auxiliar");
         else nav("/");
       } else {
-        nav(`/registro?cedula=${encodeURIComponent(valor)}`);
+        nav(`/registro?cedula=${encodeURIComponent(ced)}`);
       }
     } catch (err) {
       console.error(err);
@@ -42,9 +44,7 @@ export default function LoginByCedula() {
       <input
         placeholder="Cédula"
         value={cedula}
-        onChange={(e) =>
-          setCedula(e.target.value.replace(/[^0-9a-zA-Z]/g, ""))
-        }
+        onChange={(e) => setCedula(normCed(e.target.value))}
         style={{ display: "block", width: "100%", padding: 10, marginBottom: 12 }}
       />
       <button

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -12,9 +12,12 @@ import {
   serverTimestamp,
 } from "firebase/firestore";
 
+const normCed = (s) => (s || "").toString().trim().replace(/[.\s-]/g, "");
+
 export async function getUserByCedula(cedula) {
   await ensureAuth();
-  const ref = doc(db, "users", String(cedula));
+  const id = normCed(cedula);
+  const ref = doc(db, "users", id);
   const snap = await getDoc(ref);
   if (!snap.exists()) return null;
   const data = snap.data();
@@ -28,7 +31,7 @@ export async function getUserByCedula(cedula) {
 
 export async function createUser({ cedula, nombreCompleto, correo, role }) {
   await ensureAuth();
-  const id = String(cedula).trim();
+  const id = normCed(cedula);
   const ref = doc(db, "users", id);
   await setDoc(ref, {
     cedula: id,
@@ -42,7 +45,8 @@ export async function createUser({ cedula, nombreCompleto, correo, role }) {
 
 export async function updateUserRole(cedula, role) {
   await ensureAuth();
-  const ref = doc(db, "users", String(cedula));
+  const id = normCed(cedula);
+  const ref = doc(db, "users", id);
   await updateDoc(ref, {
     role,
     updatedAt: serverTimestamp(),
@@ -62,7 +66,8 @@ export async function getUsersPage(limitN = 50) {
 
 export async function findUserByCedula(cedula) {
   await ensureAuth();
-  const ref = doc(db, "users", String(cedula));
+  const id = normCed(cedula);
+  const ref = doc(db, "users", id);
   const snap = await getDoc(ref);
   if (!snap.exists()) return null;
   return { id: snap.id, ...snap.data() };


### PR DESCRIPTION
## Summary
- Normalize cédula input in login and registration and navigate using sanitized ID
- Check for existing user before registration and store users by normalized cédula
- Centralize cédula normalization in users library for all reads/writes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'node_modules/vite/dist/node/chunks/dep-C6uTJdX2.js')*

------
https://chatgpt.com/codex/tasks/task_e_689bdf6dfb6483228b758ba34cbfe55c