### PR TITLE
Desactivar “Smart Links” de iOS para nombres y cédulas

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="format-detection" content="telephone=no, address=no, email=no, date=no">
     <title>Mi App Médica</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -91,8 +91,8 @@ export default function AdminView() {
       const isEstimado = !!p.finEstimadoAt && !p.finAt;
       return (
         <tr key={p.id}>
-          <td>{formatName(p)}</td>
-          <td>{p.cedula || "—"}</td>
+          <td><span className="no-detect">{formatName(p)}</span></td>
+          <td><span className="no-detect">{p.cedula || "—"}</span></td>
           <td>{showVal(p.edad)}</td>
           <td title={p.diagnostico || ""}>{truncate(p.diagnostico, 30)}</td>
           <td>{ingreso}</td>

--- a/src/components/AuxiliarView.jsx
+++ b/src/components/AuxiliarView.jsx
@@ -394,14 +394,17 @@ export default function AuxiliarView() {
                   <>
                     <h2>Paciente</h2>
                     <p>
-                      <b>Nombre:</b>{" "}
-                      {(
-                        paciente.nombreCompleto ||
-                        `${paciente.firstName || ""} ${paciente.lastName || ""}`.trim()
-                      ) || ""}
+                      <strong>Nombre:</strong>{" "}
+                      <span className="no-detect">
+                        {(
+                          paciente.nombreCompleto ||
+                          `${paciente.firstName || ""} ${paciente.lastName || ""}`.trim()
+                        ) || "—"}
+                      </span>
                     </p>
                     <p>
-                      <b>Cédula:</b> {paciente.cedula}
+                      <strong>Cédula:</strong>{" "}
+                      <span className="no-detect">{paciente.cedula || "—"}</span>
                     </p>
                     <p>
                       <b>Estado:</b> {paciente.status || paciente.estado || "-"}

--- a/src/components/MedicoView.jsx
+++ b/src/components/MedicoView.jsx
@@ -133,8 +133,8 @@ export default function MedicoView() {
                         : "—";
                       return (
                         <tr key={p.id}>
-                          <td>{nombre}</td>
-                          <td>{ced}</td>
+                          <td><span className="no-detect">{nombre}</span></td>
+                          <td><span className="no-detect">{ced}</span></td>
                           <td>{edadTxt}</td>
                           <td title={p.diagnostico || ""}>{dxTxt}</td>
                           <td>{ingresoDisplay(p)}</td>
@@ -202,8 +202,8 @@ export default function MedicoView() {
                         : "—";
                       return (
                         <tr key={p.id}>
-                          <td>{nombre}</td>
-                          <td>{ced}</td>
+                          <td><span className="no-detect">{nombre}</span></td>
+                          <td><span className="no-detect">{ced}</span></td>
                           <td>{edadTxt}</td>
                           <td title={p.diagnostico || ""}>{dxTxt}</td>
                           <td>{ingresoDisplay(p)}</td>

--- a/src/index.css
+++ b/src/index.css
@@ -169,3 +169,24 @@ input, textarea, button { font: inherit; }
   margin-bottom: 12px;
 }
 
+a[x-apple-data-detectors]{
+  color:inherit !important;
+  text-decoration:none !important;
+  pointer-events:none !important;
+  cursor:default !important;
+}
+a[href^="tel:"],
+a[href^="mailto:"],
+a[href^="maps:"],
+a[href^="http://maps.apple.com"],
+a[href^="https://maps.apple.com"]{
+  color:inherit !important;
+  text-decoration:none !important;
+  pointer-events:none !important;
+  cursor:default !important;
+}
+/* Clase para texto que no debe “detectarse” en iOS */
+.no-detect{
+  -webkit-touch-callout:none;
+}
+


### PR DESCRIPTION
## Summary
- Disable telephone, address, email and date auto detection in index.html
- Add global CSS rules to neutralize iOS smart links and provide `no-detect` class
- Wrap patient name and ID in `no-detect` spans across admin, medical and auxiliary views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'vite/dist/node/chunks/dep-C6uTJdX2.js')*

------
https://chatgpt.com/codex/tasks/task_e_689ceaec99848322a33dc837e4acff50