### PR TITLE
feat: protect routes and add global logout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,33 +1,89 @@
-import React, { useEffect, useState } from "react";
-import { onAuthStateChanged } from "firebase/auth";
-import { auth } from "./firebaseConfig";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import AdminView from "./components/AdminView.jsx";
 import MedicoView from "./components/MedicoView.jsx";
 import AuxiliarView from "./components/AuxiliarView.jsx";
+import PatientDetail from "./components/PatientDetail.jsx";
 import Login from "./components/Login.jsx";
 
-export default function App() {
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      setUser(currentUser);
-    });
-    return () => unsubscribe();
-  }, []);
-
-  if (!user) {
-    return <Login />;
+export function getRole() {
+  try {
+    return (localStorage.getItem("role") || "").toLowerCase();
+  } catch {
+    return "";
   }
-
-  if (user.email === "admin@tuapp.com") {
-    return <AdminView user={user} />;
-  }
-
-  if (user.email === "medico@tuapp.com") {
-    return <MedicoView user={user} />;
-  }
-
-  return <AuxiliarView user={user} />;
 }
 
+export function hasAccess(role, route) {
+  role = (role || "").toLowerCase();
+  const r = (route || "").toLowerCase();
+  if (["admin", "superadmin"].includes(role)) {
+    return (
+      r.startsWith("/admin") ||
+      r.startsWith("/medico") ||
+      r.startsWith("/auxiliar") ||
+      r.startsWith("/paciente/")
+    );
+  }
+  if (role === "medico") {
+    return r.startsWith("/medico") || r.startsWith("/paciente/");
+  }
+  if (role === "auxiliar") {
+    return r.startsWith("/auxiliar") || r.startsWith("/paciente/");
+  }
+  return false;
+}
+
+function ProtectedRoute({ element, allow = [] }) {
+  const role = getRole();
+  const location = useLocation();
+  const allowed = allow.map((r) => r.toLowerCase());
+  if (!role || !allowed.includes(role) || !hasAccess(role, location.pathname)) {
+    return <Navigate to="/" replace />;
+  }
+  return element;
+}
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Login />} />
+      <Route
+        path="/admin"
+        element={
+          <ProtectedRoute
+            allow={["admin", "superadmin"]}
+            element={<AdminView />}
+          />
+        }
+      />
+      <Route
+        path="/medico"
+        element={
+          <ProtectedRoute
+            allow={["medico", "admin", "superadmin"]}
+            element={<MedicoView />}
+          />
+        }
+      />
+      <Route
+        path="/auxiliar"
+        element={
+          <ProtectedRoute
+            allow={["auxiliar", "admin", "superadmin"]}
+            element={<AuxiliarView />}
+          />
+        }
+      />
+      <Route
+        path="/paciente/:id"
+        element={
+          <ProtectedRoute
+            allow={["medico", "auxiliar", "admin", "superadmin"]}
+            element={<PatientDetail />}
+          />
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -10,8 +10,9 @@ import {
 import { useNavigate } from "react-router-dom";
 import { db } from "../firebaseConfig";
 import PatientForm from "./PatientForm";
-import LogoutButton from "./LogoutButton";
 import RoleSwitcher from "./RoleSwitcher";
+import TopBar from "./TopBar";
+import SuperNav from "./SuperNav";
 import { ingresoDisplay, finDisplay } from "../utils/dates";
 import { isAdmin } from "../utils/roles";
 import { isSuperAdminLocal } from "../lib/users";
@@ -165,14 +166,15 @@ export default function AdminView() {
 
   return (
     <div className="page">
+      {isSuperAdminLocal() && <SuperNav />}
       <div className="container">
+        <TopBar title="Panel Admin" />
         <div className="section-header">
           <h1 className="section-title">Pacientes</h1>
           <div style={{ display: "flex", gap: 8 }}>
             {isAdmin() && (
               <button className="btn" onClick={() => navigate("/usuarios")}>Usuarios</button>
             )}
-            <LogoutButton />
             {isSuperAdminLocal() && <RoleSwitcher />}
           </div>
         </div>

--- a/src/components/AuxiliarView.jsx
+++ b/src/components/AuxiliarView.jsx
@@ -14,8 +14,9 @@ import {
 } from "firebase/firestore";
 import { db } from "../firebaseConfig";
 import VitalCharts from "./VitalCharts";
-import LogoutButton from "./LogoutButton";
 import RoleSwitcher from "./RoleSwitcher";
+import TopBar from "./TopBar";
+import SuperNav from "./SuperNav";
 import { parseBP as parseBPRaw } from "../utils/bp";
 import { finDisplay } from "../utils/dates";
 import { isAdmin as _isAdmin, assertAdmin as _assertAdmin } from "../utils/roles";
@@ -357,11 +358,12 @@ export default function AuxiliarView() {
 
   return (
     <div className="page">
+      {isSuperAdminLocal() && <SuperNav />}
       <div className="container">
+        <TopBar title="Panel Auxiliar" />
         <div className="section-header">
           <h1 className="section-title">Auxiliar – Registro de signos</h1>
           <div style={{ display: "flex", gap: 8 }}>
-            <LogoutButton />
             {isSuperAdminLocal() && <RoleSwitcher />}
           </div>
         </div>

--- a/src/components/MedicoView.jsx
+++ b/src/components/MedicoView.jsx
@@ -9,8 +9,9 @@ import {
   updateDoc,
   serverTimestamp,
 } from "firebase/firestore";
-import LogoutButton from "./LogoutButton";
 import RoleSwitcher from "./RoleSwitcher";
+import TopBar from "./TopBar";
+import SuperNav from "./SuperNav";
 import { asDate, ingresoDisplay, finDisplay } from "../utils/dates";
 import { isSuperAdminLocal } from "../lib/users";
 
@@ -71,11 +72,12 @@ export default function MedicoView() {
 
   return (
     <div className="page">
+      {isSuperAdminLocal() && <SuperNav />}
       <div className="container">
+        <TopBar title="Panel Médico" />
         <div className="section-header">
           <h1 className="section-title">Pacientes</h1>
           <div style={{ display: "flex", gap: 8 }}>
-            <LogoutButton />
             {isSuperAdminLocal() && <RoleSwitcher />}
           </div>
         </div>

--- a/src/components/PatientDetail.jsx
+++ b/src/components/PatientDetail.jsx
@@ -14,7 +14,9 @@ import {
 } from "firebase/firestore";
 import { parseBP } from "../utils/bp";
 import VitalCharts from "./VitalCharts";
-import LogoutButton from "./LogoutButton";
+import TopBar from "./TopBar";
+import SuperNav from "./SuperNav";
+import { isSuperAdminLocal } from "../lib/users";
 
 function showVal(v) {
   return v || v === 0 ? String(v) : "—";
@@ -123,13 +125,13 @@ export default function PatientDetail() {
   if (patient === undefined) {
     return (
       <div className="page">
+        {isSuperAdminLocal() && <SuperNav />}
         <div className="container">
+          <TopBar title="Detalle del paciente" />
           <div className="section-header">
             <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
               <button className="btn" onClick={handleBack}>← Volver</button>
-              <h1 className="section-title">Detalle del paciente</h1>
             </div>
-            <LogoutButton />
           </div>
           <p>Cargando...</p>
         </div>
@@ -140,13 +142,13 @@ export default function PatientDetail() {
   if (patient === null) {
     return (
       <div className="page">
+        {isSuperAdminLocal() && <SuperNav />}
         <div className="container">
+          <TopBar title="Detalle del paciente" />
           <div className="section-header">
             <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
               <button className="btn" onClick={handleBack}>← Volver</button>
-              <h1 className="section-title">Detalle del paciente</h1>
             </div>
-            <LogoutButton />
           </div>
           <p>Paciente no encontrado.</p>
         </div>
@@ -156,13 +158,13 @@ export default function PatientDetail() {
 
   return (
     <div className="page">
+      {isSuperAdminLocal() && <SuperNav />}
       <div className="container">
+        <TopBar title="Detalle del paciente" />
         <div className="section-header">
           <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
             <button className="btn" onClick={handleBack}>← Volver</button>
-            <h1 className="section-title">Detalle del paciente</h1>
           </div>
-          <LogoutButton />
         </div>
 
         <style>{`

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,0 +1,14 @@
+export default function TopBar({ title }) {
+  const logout = () => {
+    localStorage.clear();
+    window.location.href = "/";
+  };
+  return (
+    <div className="section-header" style={{ marginBottom: 20 }}>
+      <h1 className="section-title">{title}</h1>
+      <button className="btn" onClick={logout}>
+        Cerrar sesión
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add role utilities and protected routes for admin, medico, auxiliar and patient detail views
- introduce reusable TopBar with logout button and integrate SuperNav for superadmin
- update views to use TopBar and enforce role-based navigation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e9f81c5b48322941f2bcfc02e1ba5