### PR TITLE
feat: allow registration for unregistered emails

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import MedicoView from "./components/MedicoView.jsx";
 import AuxiliarView from "./components/AuxiliarView.jsx";
 import PatientDetail from "./components/PatientDetail.jsx";
 import AccessByEmail from "./components/AccessByEmail.jsx";
+import CreateAccount from "./components/CreateAccount.jsx";
 import { destinationForRole } from "./lib/auth";
 
 export function getRole() {
@@ -53,6 +54,7 @@ export default function App() {
         element={<Navigate to={role ? destinationForRole(role) : "/login"} replace />}
       />
       <Route path="/login" element={<AccessByEmail />} />
+      <Route path="/create-account" element={<CreateAccount />} />
       <Route
         path="/admin"
         element={

--- a/src/components/AccessByEmail.jsx
+++ b/src/components/AccessByEmail.jsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { findUserByEmail, resolveRole, destinationForRole, normalizeEmail } from "../lib/auth";
+import {
+  findUserByEmail,
+  resolveRole,
+  destinationForRole,
+  normalizeEmail,
+} from "../lib/auth";
 
 export default function AccessByEmail() {
   const [email, setEmail] = useState("");
@@ -20,7 +25,8 @@ export default function AccessByEmail() {
     try {
       const user = await findUserByEmail(value);
       if (!user) {
-        setError("No se encontró tu correo. Solicita registro al administrador.");
+        setError("No se encontró tu correo. Te llevaremos al registro.");
+        navigate(`/create-account?email=${encodeURIComponent(value)}`);
         return;
       }
 
@@ -46,7 +52,7 @@ export default function AccessByEmail() {
     <div className="max-w-md mx-auto p-6">
       <h1 className="text-2xl font-semibold mb-2">Acceso del personal</h1>
       <p className="text-gray-600 mb-6">
-        Ingresa con correo registrado. Si no estás en la lista, solicita tu registro al administrador.
+        Ingresa con correo registrado. Si no estás en la lista, podrás registrarte.
       </p>
 
       <form onSubmit={onSubmit} className="space-y-3">

--- a/src/components/CreateAccount.jsx
+++ b/src/components/CreateAccount.jsx
@@ -1,0 +1,105 @@
+import React, { useMemo, useState } from "react";
+import { collection, addDoc, serverTimestamp } from "firebase/firestore";
+import { db } from "../firebaseConfig";
+import { useNavigate, useLocation } from "react-router-dom";
+
+function useQuery() {
+  const { search } = useLocation();
+  return useMemo(() => new URLSearchParams(search), [search]);
+}
+
+export default function CreateAccount() {
+  const q = useQuery();
+  const navigate = useNavigate();
+
+  const [nombre, setNombre] = useState("");
+  const [apellido, setApellido] = useState("");
+  const [cedula, setCedula] = useState("");
+  const [correo, setCorreo] = useState((q.get("email") || "").toLowerCase());
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    const payload = {
+      nombreCompleto: `${(nombre || "").trim()} ${(apellido || "").trim()}`.trim(),
+      cedula: (cedula || "").trim(),
+      correo: (correo || "").trim().toLowerCase(),
+      role: "auxiliar",
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    };
+    if (!payload.nombreCompleto || !payload.cedula || !payload.correo) {
+      setMsg("Completa todos los campos.");
+      return;
+    }
+
+    setSaving(true);
+    setMsg("");
+    try {
+      await addDoc(collection(db, "users"), payload);
+      // Persist session data similar to login
+      localStorage.setItem("role", "auxiliar");
+      localStorage.setItem("userEmail", payload.correo);
+      localStorage.setItem("userName", payload.nombreCompleto);
+      localStorage.setItem("userCedula", payload.cedula);
+      setMsg("Usuario creado correctamente. Redirigiendo…");
+      navigate("/auxiliar");
+    } catch (err) {
+      console.error(err);
+      setMsg("No se pudo crear el usuario.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">Registro de personal</h1>
+      <form onSubmit={onSubmit} className="space-y-3">
+        <label className="block text-sm font-medium">Nombre</label>
+        <input
+          className="w-full border rounded px-3 py-2"
+          value={nombre}
+          onChange={(e) => setNombre(e.target.value)}
+          required
+        />
+
+        <label className="block text-sm font-medium">Apellido</label>
+        <input
+          className="w-full border rounded px-3 py-2"
+          value={apellido}
+          onChange={(e) => setApellido(e.target.value)}
+          required
+        />
+
+        <label className="block text-sm font-medium">Cédula</label>
+        <input
+          className="w-full border rounded px-3 py-2"
+          value={cedula}
+          onChange={(e) => setCedula(e.target.value)}
+          required
+        />
+
+        <label className="block text-sm font-medium">Correo</label>
+        <input
+          type="email"
+          className="w-full border rounded px-3 py-2"
+          value={correo}
+          onChange={(e) => setCorreo(e.target.value)}
+          required
+        />
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="w-full bg-blue-600 disabled:opacity-60 text-white rounded px-3 py-2"
+        >
+          {saving ? "Guardando…" : "Registrarme"}
+        </button>
+      </form>
+      {msg && <p className="mt-2 text-gray-700">{msg}</p>}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- redirect unregistered emails to a dedicated registration form
- add create account view that auto-assigns auxiliar role and saves session data
- wire /create-account route in the app router

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f43fe80008322a4df044465c6a726