### PR TITLE
feat: normalize cedulas to digits, remove Users button, and mask superadmin label as “Médico”

### DIFF
--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -18,6 +18,7 @@ import SuperNav from "./SuperNav";
 import { ingresoDisplay, finDisplay } from "../utils/dates";
 import { isAdmin } from "../utils/roles";
 import { isSuperAdminLocal } from "../lib/users";
+import { displayCedula } from "../utils/format";
 
 function formatName(p) {
   const name = (p.nombreCompleto || `${p.firstName || ""} ${p.lastName || ""}`).trim();
@@ -121,7 +122,9 @@ export default function AdminView() {
       return (
         <tr key={p.id}>
           <td><span className="no-detect">{formatName(p)}</span></td>
-          <td><span className="no-detect">{p.cedula || "—"}</span></td>
+          <td>
+            <span className="no-detect">{displayCedula(p.cedula) || "—"}</span>
+          </td>
           <td>{showVal(p.edad)}</td>
           <td title={p.diagnostico || ""}>{truncate(p.diagnostico, 30)}</td>
           <td>{ingreso}</td>
@@ -200,18 +203,6 @@ export default function AdminView() {
         <div className="section-header">
           <h1 className="section-title">Pacientes</h1>
           <div style={{ display: "flex", gap: 8 }}>
-            {isAdmin() && (
-              <button
-                type="button"
-                onClick={() => {
-                  const el = document.getElementById("usuarios");
-                  if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
-                }}
-                className="btn"
-              >
-                Usuarios
-              </button>
-            )}
             {isSuperAdminLocal() && <RoleSwitcher />}
           </div>
         </div>
@@ -258,7 +249,7 @@ export default function AdminView() {
                   {users.map((u) => (
                     <tr key={u.id}>
                       <td>{u.nombreCompleto || "—"}</td>
-                      <td>{u.cedula || "—"}</td>
+                      <td>{displayCedula(u.cedula) || "—"}</td>
                       <td>{u.correo || "—"}</td>
                       <td style={{ textTransform: "capitalize" }}>{u.role || "—"}</td>
                       <td>{fdate(u.updatedAt || u.createdAt)}</td>

--- a/src/components/AuxiliarView.jsx
+++ b/src/components/AuxiliarView.jsx
@@ -21,6 +21,7 @@ import { parseBP as parseBPRaw } from "../utils/bp";
 import { finDisplay } from "../utils/dates";
 import { isAdmin as _isAdmin, assertAdmin as _assertAdmin } from "../utils/roles";
 import { isSuperAdminLocal } from "../lib/users";
+import { normalizeCedula, displayCedula } from "../utils/format";
 
 function showVal(v) {
   return v || v === 0 ? String(v) : "—";
@@ -191,9 +192,9 @@ export default function AuxiliarView() {
       vitalsUnsub.current = null;
     }
 
-    const ced = cedulaBuscar.trim();
+    const ced = normalizeCedula(cedulaBuscar);
     if (!ced) {
-      setInfo("Escribe una cédula para buscar.");
+      setInfo("Ingresa una cédula válida");
       return;
     }
     try {
@@ -406,7 +407,7 @@ export default function AuxiliarView() {
                     </p>
                     <p>
                       <strong>Cédula:</strong>{" "}
-                      <span className="no-detect">{paciente.cedula || "—"}</span>
+                      <span className="no-detect">{displayCedula(paciente.cedula) || "—"}</span>
                     </p>
                     <p>
                       <b>Estado:</b> {paciente.status || paciente.estado || "-"}

--- a/src/components/MedicoView.jsx
+++ b/src/components/MedicoView.jsx
@@ -14,6 +14,7 @@ import TopBar from "./TopBar";
 import SuperNav from "./SuperNav";
 import { asDate, ingresoDisplay, finDisplay } from "../utils/dates";
 import { isSuperAdminLocal } from "../lib/users";
+import { displayCedula } from "../utils/format";
 
 export default function MedicoView() {
   const nav = useNavigate();
@@ -125,7 +126,7 @@ export default function MedicoView() {
                         p.nombreCompleto ||
                         `${p.firstName || ""} ${p.lastName || ""}` ||
                         "—";
-                      const ced = p.cedula || "—";
+                      const ced = displayCedula(p.cedula) || "—";
                       const edadTxt =
                         p.edad || p.edad === 0 ? String(p.edad) : "—";
                       const dxTxt = p.diagnostico
@@ -194,7 +195,7 @@ export default function MedicoView() {
                         p.nombreCompleto ||
                         `${p.firstName || ""} ${p.lastName || ""}` ||
                         "—";
-                      const ced = p.cedula || "—";
+                      const ced = displayCedula(p.cedula) || "—";
                       const edadTxt =
                         p.edad || p.edad === 0 ? String(p.edad) : "—";
                       const dxTxt = p.diagnostico

--- a/src/components/PatientDetail.jsx
+++ b/src/components/PatientDetail.jsx
@@ -17,6 +17,7 @@ import VitalCharts from "./VitalCharts";
 import TopBar from "./TopBar";
 import SuperNav from "./SuperNav";
 import { isSuperAdminLocal } from "../lib/users";
+import { displayCedula } from "../utils/format";
 
 function showVal(v) {
   return v || v === 0 ? String(v) : "—";
@@ -187,7 +188,7 @@ export default function PatientDetail() {
               <b>Nombre:</b> {patient.nombreCompleto || `${patient.firstName || ""} ${patient.lastName || ""}`.trim() || "—"}
             </div>
             <div style={{ marginBottom: 8 }}>
-              <b>Cédula:</b> {patient.cedula || "—"}
+              <b>Cédula:</b> {displayCedula(patient.cedula) || "—"}
             </div>
             <div style={{ marginBottom: 8 }}>
               <b>Edad:</b> {showVal(patient.edad)}

--- a/src/components/PatientForm.jsx
+++ b/src/components/PatientForm.jsx
@@ -12,6 +12,7 @@ import {
   updateDoc,
 } from "firebase/firestore";
 import { assertAdmin } from "../utils/roles";
+import { normalizeCedula } from "../utils/format";
 
 function showVal(v) {
   return v || v === 0 ? String(v) : "—";
@@ -60,9 +61,10 @@ export default function PatientForm({
   const submit = async (e) => {
     e.preventDefault();
     setError("");
+    const cedulaNorm = normalizeCedula(form.cedula);
     if (
       !form.nombreCompleto.trim() ||
-      !form.cedula.trim() ||
+      !cedulaNorm ||
       !form.finEstimado
     ) {
       setError(
@@ -89,7 +91,7 @@ export default function PatientForm({
         assertAdmin();
         const payload = {
           nombreCompleto: form.nombreCompleto.trim(),
-          cedula: String(form.cedula).trim(),
+          cedula: cedulaNorm,
           edad: nEdad,
           diagnostico: diag,
           finEstimadoAt: finEstimadoDate
@@ -102,7 +104,7 @@ export default function PatientForm({
       } else {
         const q = query(
           collection(db, "patients"),
-          where("cedula", "==", String(form.cedula).trim())
+          where("cedula", "==", cedulaNorm)
         );
         const snap = await getDocs(q);
         if (!snap.empty) {
@@ -112,7 +114,7 @@ export default function PatientForm({
         }
         const nuevoPaciente = {
           nombreCompleto: form.nombreCompleto.trim(),
-          cedula: String(form.cedula).trim(),
+          cedula: cedulaNorm,
           status: "pendiente",
           fechaIngreso: serverTimestamp(),
           ingresoAt: serverTimestamp(),

--- a/src/components/SuperNav.jsx
+++ b/src/components/SuperNav.jsx
@@ -1,10 +1,31 @@
 // src/components/SuperNav.jsx
 import { useNavigate, useLocation } from "react-router-dom";
 
+const SUPER_ADMINS = (import.meta.env.VITE_SUPER_ADMINS || "")
+  .split(",")
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
 export default function SuperNav() {
   const nav = useNavigate();
   const { pathname } = useLocation();
-  const name = localStorage.getItem("userName");
+  const storedUser = JSON.parse(localStorage.getItem("user") || "{}");
+  const name =
+    localStorage.getItem("userName") || storedUser.nombreCompleto || "";
+  const email =
+    (storedUser.email || localStorage.getItem("userEmail") || "").toLowerCase();
+  const roleReal = localStorage.getItem("role") || "";
+
+  function getDisplayRole(rolReal, email) {
+    if (SUPER_ADMINS.includes((email || "").toLowerCase())) return "Médico";
+    const map = {
+      superadmin: "Super Admin",
+      admin: "Admin",
+      medico: "Médico",
+      auxiliar: "Auxiliar",
+    };
+    return map[rolReal] || "—";
+  }
 
   const Btn = ({ to, children }) => (
     <button
@@ -23,16 +44,18 @@ export default function SuperNav() {
   );
 
   return (
-    <div style={{
-      position: "sticky",
-      top: 0,
-      zIndex: 10,
-      background: "#fff",
-      borderBottom: "1px solid #eee",
-      padding: "10px 12px",
-      marginBottom: 8
-    }}>
-      <b>Super Admin:</b>{" "}
+    <div
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 10,
+        background: "#fff",
+        borderBottom: "1px solid #eee",
+        padding: "10px 12px",
+        marginBottom: 8,
+      }}
+    >
+      <b>{getDisplayRole(roleReal, email)}:</b>{" "}
       {name && <span style={{ marginRight: 8 }}>{name}</span>}
       <Btn to="/admin">Admin</Btn>
       <Btn to="/medico">Médico</Btn>

--- a/src/lib/patients.js
+++ b/src/lib/patients.js
@@ -1,28 +1,72 @@
 import { db } from "../firebaseConfig";
 import {
-  doc,setDoc,getDoc,updateDoc,collection,query,where,
-  getDocs,serverTimestamp,addDoc,orderBy
+  doc,
+  setDoc,
+  getDoc,
+  updateDoc,
+  collection,
+  query,
+  where,
+  getDocs,
+  serverTimestamp,
+  addDoc,
+  orderBy,
 } from "firebase/firestore";
+import { normalizeCedula } from "../utils/format";
 
 export async function createPatient({ cedula, nombre, apellido }) {
-  const ref = doc(db, "patients", String(cedula));
-  await setDoc(ref, { cedula:String(cedula), nombre:nombre||"", apellido:apellido||"", estado:"pendiente", createdAt: serverTimestamp() }, { merge:true });
+  const id = normalizeCedula(cedula);
+  const ref = doc(db, "patients", id);
+  await setDoc(
+    ref,
+    {
+      cedula: id,
+      nombre: nombre || "",
+      apellido: apellido || "",
+      estado: "pendiente",
+      createdAt: serverTimestamp(),
+    },
+    { merge: true }
+  );
   return (await getDoc(ref)).data();
 }
+
 export async function listPatientsByEstado(estado) {
-  const q = query(collection(db,"patients"), where("estado","==",estado));
-  const s = await getDocs(q); return s.docs.map(d=>d.data());
+  const q = query(collection(db, "patients"), where("estado", "==", estado));
+  const s = await getDocs(q);
+  return s.docs.map((d) => d.data());
 }
+
 export async function setEstado(cedula, estado) {
-  const ref = doc(db,"patients", String(cedula));
-  const payload = { estado }; if (estado==="finalizado") payload.fechaFin = serverTimestamp();
-  await updateDoc(ref, payload); return (await getDoc(ref)).data();
+  const id = normalizeCedula(cedula);
+  const ref = doc(db, "patients", id);
+  const payload = { estado };
+  if (estado === "finalizado") payload.fechaFin = serverTimestamp();
+  await updateDoc(ref, payload);
+  return (await getDoc(ref)).data();
 }
-export async function getPatient(cedula){ const s=await getDoc(doc(db,"patients",String(cedula))); return s.exists()?s.data():null; }
-export async function addVitals(cedula, vitals, meta={}) {
-  await addDoc(collection(db,"patients",String(cedula),"vitals"), { ...vitals, ...meta, createdAt: serverTimestamp() });
+
+export async function getPatient(cedula) {
+  const id = normalizeCedula(cedula);
+  const s = await getDoc(doc(db, "patients", id));
+  return s.exists() ? s.data() : null;
 }
+
+export async function addVitals(cedula, vitals, meta = {}) {
+  const id = normalizeCedula(cedula);
+  await addDoc(collection(db, "patients", id, "vitals"), {
+    ...vitals,
+    ...meta,
+    createdAt: serverTimestamp(),
+  });
+}
+
 export async function listVitals(cedula) {
-  const q = query(collection(db,"patients",String(cedula),"vitals"), orderBy("createdAt","asc"));
-  const s = await getDocs(q); return s.docs.map(d=>d.data());
+  const id = normalizeCedula(cedula);
+  const q = query(
+    collection(db, "patients", id, "vitals"),
+    orderBy("createdAt", "asc")
+  );
+  const s = await getDocs(q);
+  return s.docs.map((d) => d.data());
 }

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,8 @@
+export function normalizeCedula(value) {
+  if (value == null) return "";
+  return String(value).replace(/[^\d]/g, "");
+}
+
+export function displayCedula(value) {
+  return normalizeCedula(value);
+}


### PR DESCRIPTION
## Summary
- add shared helpers to normalize and display cédulas as digits
- normalize cédulas when creating patients and searching by cédula
- drop the Users header button and keep the user table inline
- show superadmins as “Médico” in navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f486b64188322917bae49acfb9d48