### PR TITLE
feat: redesign home landing with color tokens

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,155 +1,156 @@
+/* eslint-disable react/no-unescaped-entities */
+import React from "react";
 import { Link } from "react-router-dom";
-import {
-  Home as HomeIcon,
-  ClipboardList,
-  Stethoscope,
-  Pill,
-  Shield,
-  Users,
-} from "lucide-react";
 
-/**
- * Landing minimalista sin imágenes locales.
- * Usa tokens y utilidades ya cargadas (tokens.css, lovable.css, tailwind).
- */
 export default function Home() {
   return (
-    <div>
-      {/* Header simple */}
-      <header className="border-b border-[hsl(var(--border))] bg-[hsl(var(--panel))]">
-        <div className="container-app flex items-center justify-between py-4">
-          <div className="flex items-center gap-3">
-            <div className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-[hsl(var(--primary))] text-white">
-              <HomeIcon size={20} />
+    <div
+      className="min-h-screen"
+      style={{ background: "var(--color-bg)", color: "var(--color-foreground, #0f172a)" }}
+    >
+      {/* Top bar */}
+      <header className="w-full border-b" style={{ borderColor: "var(--color-border)" }}>
+        <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div
+              className="w-8 h-8 rounded-md flex items-center justify-center"
+              style={{ background: "rgba(26,106,255,0.12)", color: "var(--color-primary)" }}
+            >
+              <span className="text-sm font-semibold">H</span>
             </div>
-            <div className="font-semibold tracking-tight">
-              Programa de hospitalización en Domicilio
-            </div>
+            <span className="font-medium">Programa de hospitalización en Domicilio</span>
           </div>
-          <nav className="hidden md:flex items-center gap-6 text-[hsl(var(--muted))]">
-            <a href="#features" className="hover:underline">Inicio</a>
-            <a href="#equipo" className="hover:underline">Para el equipo</a>
-          </nav>
-          <Link to="/ingreso" className="btn">
+          <Link
+            to="/acceso"
+            className="inline-flex items-center gap-2 px-4 h-9 rounded-md font-medium"
+            style={{ background: "var(--color-primary)", color: "#fff" }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-primary-600)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "var(--color-primary)")}
+          >
             Ingresar
           </Link>
         </div>
       </header>
 
       {/* Hero */}
-      <section className="bg-[hsl(var(--bg))]">
-        <div className="container-app py-12 md:py-16">
-          <div className="max-w-3xl">
-            <h1 className="section-title">Hospitalización en Casa</h1>
-            <p className="mt-3 text-[hsl(var(--muted))] leading-relaxed">
-              Portal del Programa de hospitalización en Domicilio para personal autorizado.
-              Gestión segura y organizada del cuidado.
-            </p>
-
-            <div className="mt-6 flex items-center gap-3">
-              <a href="#programa" className="btn bg-white text-[hsl(var(--primary))] border border-[hsl(var(--border))] hover:bg-[hsl(var(--primary)/0.06)]">
-                Conocer el programa
-              </a>
-              <Link to="/ingreso" className="btn">
-                Acceder al sistema
-              </Link>
+      <section className="max-w-6xl mx-auto px-4 py-12">
+        <div
+          className="rounded-lg p-8 shadow"
+          style={{ background: "var(--color-panel)", boxShadow: "var(--shadow-md, 0 4px 12px rgba(16,24,40,0.08))", border: "1px solid var(--color-border)" }}
+        >
+          <div className="grid md:grid-cols-2 gap-8 items-center">
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-4">
+                Hospitalización en Casa
+              </h1>
+              <p className="text-sm md:text-base opacity-80 mb-6">
+                Portal del Programa de hospitalización en Domicilio para personal autorizado.
+                Gestión segura y organizada del cuidado.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <a
+                  href="#programa"
+                  className="inline-flex items-center justify-center px-4 py-2 rounded-md font-semibold border"
+                  style={{ borderColor: "var(--color-border)", background: "var(--color-panel)" }}
+                >
+                  Conocer el programa
+                </a>
+                <Link
+                  to="/acceso"
+                  className="inline-flex items-center justify-center px-4 py-2 rounded-md font-semibold"
+                  style={{ background: "var(--color-primary)", color: "#fff" }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-primary-600)")}
+                  onMouseLeave={(e) => (e.currentTarget.style.background = "var(--color-primary)")}
+                >
+                  Acceder al sistema
+                </Link>
+              </div>
+              <p className="mt-6 text-xs opacity-60">
+                Responsable institucional: Evelyn Grau, Jefe de Enfermeras.
+              </p>
             </div>
 
-            <div className="mt-6 text-sm text-[hsl(var(--muted))]">
-              Responsable institucional: Evelyn Grau, Jefe de Enfermeras.
+            {/* Placeholder visual (sin imagen real) */}
+            <div className="hidden md:flex items-center justify-center">
+              <div
+                className="w-full h-56 rounded-xl border"
+                style={{
+                  borderColor: "var(--color-border)",
+                  background:
+                    "linear-gradient(135deg, rgba(26,106,255,0.08), rgba(26,106,255,0.02))",
+                }}
+              />
             </div>
           </div>
         </div>
       </section>
 
-      {/* Features principales */}
-      <section id="programa" className="bg-[hsl(var(--bg))]">
-        <div className="container-app py-10">
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-            <FeatureCard
-              icon={<ClipboardList size={28} />}
-              title="Coordinación clínica"
-              description="Interdisciplinaria para garantizar la continuidad del cuidado."
-            />
-            <FeatureCard
-              icon={<Pill size={28} />}
-              title="Gestión de insumos"
-              description="Control de insumos/medicación con seguimiento riguroso."
-            />
-            <FeatureCard
-              icon={<Stethoscope size={28} />}
-              title="Seguimiento continuo"
-              description="Evolución y continuidad del cuidado personalizado."
-            />
-            <FeatureCard
-              icon={<Shield size={28} />}
-              title="Seguridad del paciente"
-              description="Buenas prácticas y seguridad en cada intervención."
-            />
-          </div>
+      {/* Pilares */}
+      <section id="programa" className="max-w-6xl mx-auto px-4 py-10">
+        <div className="grid md:grid-cols-4 gap-6">
+          {[
+            { title: "Coordinación clínica", desc: "Interdisciplinaria para garantizar continuidad.", icon: "🗂️" },
+            { title: "Gestión de insumos", desc: "Control de insumos/medicación con seguimiento.", icon: "📦" },
+            { title: "Seguimiento continuo", desc: "Evolución y continuidad del cuidado.", icon: "📈" },
+            { title: "Seguridad del paciente", desc: "Buenas prácticas en cada intervención.", icon: "🛡️" },
+          ].map((card, i) => (
+            <div
+              key={i}
+              className="rounded-xl p-5 shadow-sm"
+              style={{
+                background: "var(--color-panel)",
+                border: "1px solid var(--color-border)",
+                boxShadow: "var(--shadow-sm, 0 1px 2px rgba(16,24,40,0.04))",
+              }}
+            >
+              <div
+                className="w-10 h-10 rounded-md mb-3 flex items-center justify-center text-lg"
+                style={{ background: "rgba(26,106,255,0.12)", color: "var(--color-primary)" }}
+              >
+                {card.icon}
+              </div>
+              <h3 className="font-semibold mb-1">{card.title}</h3>
+              <p className="text-sm opacity-70">{card.desc}</p>
+            </div>
+          ))}
         </div>
       </section>
 
-      {/* Para el equipo */}
-      <section id="equipo" className="bg-[hsl(var(--bg))]">
-        <div className="container-app py-12">
-          <h2 className="section-title">Para el equipo</h2>
-          <p className="mt-2 text-[hsl(var(--muted))]">
-            El acceso es únicamente para personal del programa.
-          </p>
+      {/* Módulos para el equipo */}
+      <section className="max-w-6xl mx-auto px-4 pb-16">
+        <h2 className="text-2xl font-bold mb-4">Para el equipo</h2>
+        <p className="text-sm opacity-70 mb-6">
+          El acceso es únicamente para personal del programa.
+        </p>
 
-          <div className="mt-8 grid gap-6 md:grid-cols-2">
-            <ModuleItem
-              title="Gestión de pacientes"
-              icon={<Users size={22} />}
-            />
-            <ModuleItem
-              title="Pedidos y devolutivos"
-              icon={<ClipboardList size={22} />}
-            />
-            <ModuleItem
-              title="Control de inventario"
-              icon={<Pill size={22} />}
-            />
-            <ModuleItem
-              title="Reportes e indicadores"
-              icon={<Shield size={22} />}
-            />
-          </div>
+        <div className="grid md:grid-cols-2 gap-6">
+          {[
+            { title: "Gestión de pacientes", icon: "👥" },
+            { title: "Pedidos y devolutivos", icon: "🧾" },
+          ].map((m, i) => (
+            <div
+              key={i}
+              className="rounded-xl p-5 flex items-center gap-4"
+              style={{
+                background: "var(--color-panel)",
+                border: "1px solid var(--color-border)",
+                boxShadow: "var(--shadow-sm, 0 1px 2px rgba(16,24,40,0.04))",
+              }}
+            >
+              <div
+                className="w-10 h-10 rounded-md flex items-center justify-center text-lg"
+                style={{ background: "rgba(26,106,255,0.12)", color: "var(--color-primary)" }}
+              >
+                {m.icon}
+              </div>
+              <div className="flex-1">
+                <p className="font-semibold">{m.title}</p>
+                <p className="text-xs opacity-70">Disponible después del ingreso.</p>
+              </div>
+            </div>
+          ))}
         </div>
       </section>
-
-      {/* Footer */}
-      <footer className="border-t border-[hsl(var(--border))] bg-[hsl(var(--panel))]">
-        <div className="container-app py-6 text-sm text-[hsl(var(--muted))]">
-          © {new Date().getFullYear()} Programa de Hospitalización en Domicilio
-        </div>
-      </footer>
-    </div>
-  );
-}
-
-function FeatureCard({ icon, title, description }) {
-  return (
-    <div className="card p-5">
-      <div className="flex items-center gap-3">
-        <div className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-[hsl(var(--primary)/0.12)] text-[hsl(var(--primary))]">
-          {icon}
-        </div>
-        <div className="font-semibold">{title}</div>
-      </div>
-      <p className="mt-2 text-[hsl(var(--muted))] text-sm leading-relaxed">{description}</p>
-    </div>
-  );
-}
-
-function ModuleItem({ icon, title }) {
-  return (
-    <div className="card p-4 flex items-center gap-3">
-      <div className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-[hsl(var(--primary)/0.12)] text-[hsl(var(--primary))]">
-        {icon}
-      </div>
-      <div className="font-medium">{title}</div>
     </div>
   );
 }

--- a/src/styles/lovable.css
+++ b/src/styles/lovable.css
@@ -42,3 +42,8 @@ body {
   font-size: 22px;
   font-weight: 700;
 }
+
+/* <-- Añadir al final del archivo --> */
+body, .text-default {
+  color: #0f172a; /* fallback de alto contraste */
+}


### PR DESCRIPTION
## Summary
- replace Home landing with Lovable-like layout using CSS color tokens
- add high-contrast fallback color in lovable.css

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fb2af24008322b6f0e8d2722c9563