### PR TITLE
chore(routing): add Netlify SPA redirects and base role routes

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
-/*    /index.html   200
+/*  /index.html  200
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,28 +1,70 @@
 import { Suspense } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
-import AccessByEmail from "./pages/AccessByEmail.jsx";
-import NotFound from "./pages/NotFound.jsx";
-import Home from "./pages/Home.jsx";
+import AccessByEmail from "./pages/AccessByEmail";
+import NotFound from "./pages/NotFound";
 
-// Importa tus resolvers si existen; de lo contrario, comenta esas rutas.
-// import AdminResolved from "./pages/AdminResolved.jsx";
-// import MedicoResolved from "./pages/MedicoResolved.jsx";
-// import AuxiliarResolved from "./pages/AuxiliarResolved.jsx";
+// Placeholders mínimos para que las rutas existan
+function Home() {
+  return (
+    <div className="container-app">
+      <div className="card p-6">
+        <h1 className="text-2xl font-semibold mb-2">Hospitalización en Casa</h1>
+        <p className="text-gray-600 mb-4">
+          Portal del Programa de hospitalización en Domicilio para personal autorizado.
+        </p>
+        <div className="flex gap-3">
+          <a href="#programa" className="btn btn-outline">Conocer el programa</a>
+          <a href="/acceso" className="btn">Acceder al sistema</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+function AdminResolved() {
+  return (
+    <div className="container-app">
+      <div className="card p-6">
+        <h2 className="text-xl font-semibold">Panel Admin</h2>
+        <p className="text-gray-600">Ruta: /admin</p>
+      </div>
+    </div>
+  );
+}
+function MedicoResolved() {
+  return (
+    <div className="container-app">
+      <div className="card p-6">
+        <h2 className="text-xl font-semibold">Panel Médico</h2>
+        <p className="text-gray-600">Ruta: /medico</p>
+      </div>
+    </div>
+  );
+}
+function AuxiliarResolved() {
+  return (
+    <div className="container-app">
+      <div className="card p-6">
+        <h2 className="text-xl font-semibold">Panel Auxiliar</h2>
+        <p className="text-gray-600">Ruta: /auxiliar</p>
+      </div>
+    </div>
+  );
+}
 
 export default function App() {
   return (
-    <Suspense fallback={<div className="p-6">Cargando…</div>}>
+    <Suspense fallback={null}>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/acceso" element={<AccessByEmail />} />
 
-        {/**
+        {/* Rutas por rol (mínimas para evitar 404 tras login) */}
         <Route path="/admin/*" element={<AdminResolved />} />
         <Route path="/medico/*" element={<MedicoResolved />} />
         <Route path="/auxiliar/*" element={<AuxiliarResolved />} />
-        */}
+        <Route path="/superadmin/*" element={<AdminResolved />} />
 
-        {/* alias comunes (opcional) */}
+        {/* Alias comunes */}
         <Route path="/login" element={<Navigate to="/acceso" replace />} />
         <Route path="/ingresar" element={<Navigate to="/acceso" replace />} />
 

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -57,7 +57,12 @@ export function resolveRole(email, userDoc) {
 }
 
 export function destinationForRole(role) {
-  if (role === "superadmin" || role === "admin") return "/admin";
-  if (role === "medico") return "/medico";
-  return "/auxiliar";
+  const map = {
+    admin: "/admin",
+    superadmin: "/superadmin",
+    medico: "/medico",
+    auxiliar: "/auxiliar",
+    default: "/medico",
+  };
+  return map[role] || map.default;
 }

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,9 +3,10 @@ export default function NotFound() {
     <div className="container-app">
       <div className="card p-6">
         <h1 className="text-2xl font-semibold mb-2">Página no encontrada.</h1>
-        <p className="text-gray-600">
-          La ruta que intentas abrir no existe. Usa el menú para regresar.
+        <p className="text-gray-600 mb-4">
+          La ruta que intentas abrir no existe. Usa el botón para regresar.
         </p>
+        <a href="/" className="btn">Volver al inicio</a>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add Netlify `_redirects` for SPA routing
- define base placeholders for role routes and friendly 404 page
- map `destinationForRole` to new role paths

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fd5fe8f108322841d497af66896bf