### PR TITLE
Switch to HashRouter for hash-based routing fallback

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,14 +1,14 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import './index.css';
 import './styles/lovables.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace `BrowserRouter` with `HashRouter` to ensure hash-based routing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a08b565c008322becf05ac91fa4b5f