### PR TITLE
chore(netlify): add SPA redirects in netlify.toml and public/_redirects; ensure /acceso route; remove public/404.html

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,5 @@
   command = "npm run build"
 [[redirects]]
   from = "/*"
-  to   = "/index.html"
+  to = "/index.html"
   status = 200

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { Routes, Route, Navigate, Link } from "react-router-dom";
 import AccessByEmail from "./pages/AccessByEmail.jsx";
+import NotFound from "./pages/NotFound.jsx";
 
 // Vistas dummy por rol (puedes reemplazar luego)
 function Home() {
@@ -23,17 +24,6 @@ function Home() {
 function Admin() { return <div className="container-app"><div className="card p-6">Panel Admin<br/>Ruta: /admin</div></div>; }
 function Medico() { return <div className="container-app"><div className="card p-6">Panel Médico<br/>Ruta: /medico</div></div>; }
 function Auxiliar(){ return <div className="container-app"><div className="card p-6">Panel Auxiliar<br/>Ruta: /auxiliar</div></div>; }
-
-function NotFound() {
-  return (
-    <div className="container-app">
-      <div className="card p-6">
-        <h1 className="text-2xl font-semibold mb-2">Página no encontrada.</h1>
-        <p className="text-muted-foreground">La ruta que intentas abrir no existe. Usa el menú para regresar.</p>
-      </div>
-    </div>
-  );
-}
 
 export default function App() {
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,14 +1,14 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { HashRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import './styles/lovables.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <HashRouter>
+    <BrowserRouter>
       <App />
-    </HashRouter>
+    </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- use BrowserRouter and add missing /acceso catch-all route
- ensure Netlify SPA redirects are configured

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a08dc905948322bab7104ce2b251c0